### PR TITLE
Update mandelbrot_example.ipynb

### DIFF
--- a/mandelbrot_example.ipynb
+++ b/mandelbrot_example.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "def save_image(fig):\n",
     "    global image_counter\n",
-    "    filename = \"mandelbrodt_%d.png\" % image_counter\n",
+    "    filename = \"mandelbrot_%d.png\" % image_counter\n",
     "    image_counter += 1\n",
     "    fig.savefig(filename)"
    ]


### PR DESCRIPTION
Minute details, to fix a typo "mandelbrodt" -> "mandelbrot"